### PR TITLE
Fix checking required options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Checking required options `checks({required = 'string'})`
 
 ## [2.1.0] - 2018-06-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Checking required options `checks({required = 'string'})`
+- Checking nested tables
 
 ## [2.1.0] - 2018-06-19
 ### Added

--- a/checks.lua
+++ b/checks.lua
@@ -1,5 +1,15 @@
 #!/usr/bin/env tarantool
 
+local function argname_fmt(argname, key)
+    if type(key) == 'string' then
+        return string.format('%s.%s', argname, key)
+    elseif type(key) == 'number' then
+        return string.format('%s[%s]', argname, key)
+    else
+        return argname .. '[?]'
+    end
+end
+
 local function check_value(level, argname, value, expected_type)
     level = level + 1 -- escape the check_value level
 
@@ -46,7 +56,8 @@ local function check_table(level, argname, tbl, expected_fields)
 
     for expected_key, expected_type in pairs(expected_fields) do
         if type(expected_type) == 'string' then
-            -- do nothing
+            local argname = argname_fmt(argname, expected_key)
+            check_value(level, argname, tbl[expected_key], expected_type)
         elseif type(expected_type) == 'table' then
             tbl[expected_key] = tbl[expected_key] or {}
         else
@@ -58,7 +69,7 @@ local function check_table(level, argname, tbl, expected_fields)
     end
 
     for key, value in pairs(tbl) do
-        local argname = string.format('%s.%s', argname, key)
+        local argname = argname_fmt(argname, key)
         local expected_type = expected_fields[key]
         if not expected_type then
             local info = debug.getinfo(level, 'nl')

--- a/checks.lua
+++ b/checks.lua
@@ -59,6 +59,8 @@ local function check_table(level, argname, tbl, expected_fields)
             local argname = argname_fmt(argname, expected_key)
             check_value(level, argname, tbl[expected_key], expected_type)
         elseif type(expected_type) == 'table' then
+            local argname = argname_fmt(argname, expected_key)
+            check_value(level, argname, tbl[expected_key], '?table')
             tbl[expected_key] = tbl[expected_key] or {}
         else
             error(string.format(
@@ -80,10 +82,7 @@ local function check_table(level, argname, tbl, expected_fields)
         elseif type(expected_type) == 'string' then
             check_value(level, argname, value, expected_type)
         elseif type(expected_type) == 'table' then
-            check_value(level, argname, value, '?table')
-            if value then
-                check_table(level, argname, value, expected_type)
-            end
+            check_table(level, argname, value, expected_type)
         end
     end
 end

--- a/tests.lua
+++ b/tests.lua
@@ -50,6 +50,16 @@ function fn_options(options)
     })
 end
 
+local _l_array = 2 + debug.getinfo(1).currentline
+function fn_array(array)
+    checks({'number', 'number'})
+end
+
+local _l_table = 2 + debug.getinfo(1).currentline
+function fn_table(table)
+    checks({mykey = 'number'})
+end
+
 local _l_inception = 2 + debug.getinfo(1).currentline
 function fn_inception(options)
     checks({
@@ -83,7 +93,7 @@ local function test_err(test, code, expected_file, expected_line, expected_error
     -- body
 end
 
-test:plan(107)
+test:plan(120)
 test_err(test, 'fn_number_optstring(1)')
 test_err(test, 'fn_number_optstring(1, nil)')
 test_err(test, 'fn_number_optstring(2, "s")')
@@ -154,6 +164,43 @@ test_err(test, 'fn_options({mynumber = "bad"})',
 test_err(test, 'fn_options({badfield = "bad"})',
     'tests.lua', _l_options,
     'unexpected argument options.badfield to fn_options')
+
+test_err(test, 'fn_array(1)',
+    'tests.lua', _l_array,
+    'bad argument #1 to fn_array %(%?table expected, got number%)')
+test_err(test, 'fn_array()',
+    'tests.lua', _l_array,
+    'bad argument array%[1%] to fn_array %(number expected, got nil%)')
+test_err(test, 'fn_array({})',
+    'tests.lua', _l_array,
+    'bad argument array%[1%] to fn_array %(number expected, got nil%)')
+test_err(test, 'fn_array({"str1"})',
+    'tests.lua', _l_array,
+    'bad argument array%[1%] to fn_array %(number expected, got string%)')
+test_err(test, 'fn_array({1})',
+    'tests.lua', _l_array,
+    'bad argument array%[2%] to fn_array %(number expected, got nil%)')
+test_err(test, 'fn_array({1, 2})')
+test_err(test, 'fn_array({1, 2, 3})',
+    'tests.lua', _l_array,
+    'unexpected argument array%[3%] to fn_array')
+
+test_err(test, 'fn_table(1)',
+    'tests.lua', _l_table,
+    'bad argument #1 to fn_table %(%?table expected, got number%)')
+test_err(test, 'fn_table()',
+    'tests.lua', _l_table,
+    'bad argument table.mykey to fn_table %(number expected, got nil%)')
+test_err(test, 'fn_table({})',
+    'tests.lua', _l_table,
+    'bad argument table.mykey to fn_table %(number expected, got nil%)')
+test_err(test, 'fn_table({mykey = "str"})',
+    'tests.lua', _l_table,
+    'bad argument table.mykey to fn_table %(number expected, got string%)')
+test_err(test, 'fn_table({mykey = 0})')
+test_err(test, 'fn_table({mykey = 0, excess = 1})',
+    'tests.lua', _l_table,
+    'unexpected argument table.excess to fn_table')
 
 test_err(test, 'fn_inception()', nil)
 test_err(test, 'fn_inception({})', nil)

--- a/tests.lua
+++ b/tests.lua
@@ -73,6 +73,7 @@ function fn_inception(options)
             },
         },
     })
+    local _ = options.we.need.to.go.deeper
 end
 
 ------------------------------------------------------------------------------
@@ -93,7 +94,7 @@ local function test_err(test, code, expected_file, expected_line, expected_error
     -- body
 end
 
-test:plan(120)
+test:plan(121)
 test_err(test, 'fn_number_optstring(1)')
 test_err(test, 'fn_number_optstring(1, nil)')
 test_err(test, 'fn_number_optstring(2, "s")')
@@ -204,6 +205,9 @@ test_err(test, 'fn_table({mykey = 0, excess = 1})',
 
 test_err(test, 'fn_inception()', nil)
 test_err(test, 'fn_inception({})', nil)
+test_err(test, 'fn_inception({we = false})',
+    'tests.lua', _l_inception,
+    'bad argument options.we to fn_inception %(%?table expected, got boolean%)')
 test_err(test, 'fn_inception({we = {}})', nil)
 test_err(test, 'fn_inception({we = {need = {}}})', nil)
 test_err(test, 'fn_inception({we = {need = {to = {}}}})', nil)


### PR DESCRIPTION
The following code now throws an error as expected:

```
function foo(opts)
    checks({required = 'string'})
end

foo({})
```