### PR TITLE
Fix performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Performance optimization
 
+### Changed
+- Checking table type qualifiers does not change any arguments (incompatible change)
+
 ## [2.1.1] - 2018-08-22
 ### Fixed
 - Checking required options `checks({required = 'string'})`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Performance optimization
 
 ## [2.1.1] - 2018-08-22
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,13 +153,15 @@ fn_opts({my_number = 'x'}) -- error: bad argument options.my_number to fn_opts (
 fn_opts({bad_field = true}) -- error: unexpected argument options.bad_field to fn_opts
 ```
 
-When the optional argument is validated with the table type qualifier,
-its value is set to an empty table. Thus it's safe to do:
+Since v3.0 `checks` does not modify any arguments. Be careful when indexing options table:
 
 ```lua
 function fn(options)
     checks({timeout = '?number'})
-    options.timeout = options.timeout or 5.0
+    print(options.timeout) -- attempt to index local 'options' (a nil value)
+
+    options = options or {}
+    print(options.timeout) -- ok, prints nil
 end
 
 fn() -- ok

--- a/README.md
+++ b/README.md
@@ -156,15 +156,21 @@ fn_opts({bad_field = true}) -- error: unexpected argument options.bad_field to f
 Since v3.0 `checks` does not modify any arguments. Be careful when indexing options table:
 
 ```lua
-function fn(options)
+function fn_bad(options)
     checks({timeout = '?number'})
-    print(options.timeout) -- attempt to index local 'options' (a nil value)
-
-    options = options or {}
-    print(options.timeout) -- ok, prints nil
+    print(options.timeout)
 end
 
-fn() -- ok
+fn_bad() -- error: attempt to index local 'options' (a nil value)
+
+
+function fn_good(options)
+    checks({timeout = '?number'})
+    local timeout = options and options.timeout or default_value
+    print(timeout)
+end
+
+fn_good() -- ok, prints default_value
 ```
 
 When an argument inside table type qualifier is specified without question mark

--- a/checks.lua
+++ b/checks.lua
@@ -88,17 +88,17 @@ local function check_table(level, argname, tbl, expected_fields)
 end
 
 local function checks(...)
-    local arg = {...}
+    local skip = 0
 
     local level = 1
-    if type(arg[1]) == 'number' then
-        level = arg[1]
-        table.remove(arg, 1)
+    if type(...) == 'number' then
+        level = ...
+        skip = 1
     end
     level = level + 1 -- escape the checks level
 
-    for i = 1, table.maxn(arg)+1 do
-        local expected_type = arg[i]
+    for i = 1, select('#', ...) - skip + 1 do
+        local expected_type = select(i + skip, ...)
         local argname, value = debug.getlocal(level, i)
 
         if expected_type == nil and argname == nil then

--- a/checks.lua
+++ b/checks.lua
@@ -15,6 +15,8 @@ local function check_plain_type(value, expected_type)
     if type(checker) == 'function' and checker(value) == true then
         return true
     end
+
+    return false
 end
 
 local function check_multi_type(value, expected_type)

--- a/checks.lua
+++ b/checks.lua
@@ -16,7 +16,7 @@ local function check_value(level, argname, value, expected_type)
     -- 1. Check for nil if type is optional.
     if expected_type == '?' then
         return true
-    elseif expected_type:match('^%?') and value == nil then
+    elseif expected_type:startswith('?') and value == nil then
         return true
     end
 

--- a/perftest.lua
+++ b/perftest.lua
@@ -1,0 +1,81 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+local tap = require('tap')
+local json = require('json')
+local uuid = require('uuid')
+local checks = require('checks')
+local test = tap.test('performance_test')
+
+local total_time = 0
+local total_iter = 0
+
+local args = {
+    ['nil'] = nil,
+    ['string'] = 'str',
+    ['number'] = 0,
+    ['int64'] = 0LL,
+    ['uint64'] = 0ULL,
+    ['table'] = {},
+    ['meta'] = setmetatable({}, {__type = "meta"}),
+    ['uuid'] = uuid(),
+    ['uuid_str'] = uuid.str(),
+    ['uuid_bin'] = uuid.bin(),
+}
+
+local function perftest(check, argtype)
+    local fn = function(arg)
+        checks(check)
+    end
+
+    local arg = args[argtype]
+
+    local cnt = 0
+    local batch_size = 1000
+    local stop
+    local start = os.clock()
+    repeat
+        for i = 1, batch_size do
+            fn(arg)
+        end
+        cnt = cnt + batch_size
+        batch_size = math.floor(batch_size * 1.2)
+        stop = os.clock()
+    until stop - start > 1
+
+    local testname = string.format('checks(%s) (%s)', json.encode(check), argtype)
+    test:diag(string.format("  %-35s: %.2f calls/s", testname, cnt/(stop-start) ))
+end
+
+perftest('?', 'nil')
+perftest('?', 'string')
+
+perftest('string', 'string')
+
+perftest('?string', 'nil')
+perftest('?string', 'string')
+
+perftest('number|string', 'string')
+perftest('number|string', 'number')
+
+perftest('meta', 'meta')
+perftest('?string|meta', 'nil')
+perftest('?string|meta', 'string')
+perftest('?string|meta', 'meta')
+
+perftest('int64',  'number')
+perftest('int64',  'int64')
+perftest('int64',  'uint64')
+perftest('uint64', 'number')
+perftest('uint64', 'int64')
+perftest('uint64', 'uint64')
+
+perftest('uuid', 'uuid')
+perftest('uuid_str', 'uuid_str')
+perftest('uuid_bin', 'uuid_bin')
+
+perftest({x='?'}, 'table')
+perftest({x={y='?'}}, 'table')
+perftest({x={y={z='?'}}}, 'table')
+perftest({x={y={z={t='?'}}}}, 'table')
+-- TODO checks({timeout = '?number'}) -- table checker

--- a/tests.lua
+++ b/tests.lua
@@ -3,6 +3,7 @@
 require('strict').on()
 msgpack = require('msgpack')
 local tap = require('tap')
+local json = require('json')
 local checks = require('checks')
 local test = tap.test('checks_test')
 
@@ -73,7 +74,6 @@ function fn_inception(options)
             },
         },
     })
-    local _ = options.we.need.to.go.deeper
 end
 
 ------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ local function test_err(test, code, expected_file, expected_line, expected_error
     -- body
 end
 
-test:plan(122)
+test:plan(129)
 test_err(test, 'fn_number_optstring(1)')
 test_err(test, 'fn_number_optstring(1, nil)')
 test_err(test, 'fn_number_optstring(2, "s")')
@@ -234,17 +234,29 @@ test_err(test, 'fn_deepcheck(1)',
     'tests.lua', _l_deepcheck,
     'bad argument #1 to fn_deepcheck %(string expected, got number%)')
 
+local optcopy = nil
 local function check_options(options)
+    optcopy = table.deepcopy(options)
     checks({
         a = {
-            b = {
+            b1 = {
+                c = '?',
+            },
+            b2 = {
                 c = '?',
             },
         },
     })
-    test:is_deeply(options, {a={b={c=nil}}}, 'options == {a={b={c=nil}}}')
+    test:is_deeply(options, optcopy, ('checks does not modify %s'):format(json.encode(optcopy)))
 end
 check_options()
+check_options{}
+check_options{a = {}}
+check_options{a = {b1 = {}}}
+check_options{a = {b2 = {}}}
+check_options{a = {b1 = {c = 0}}}
+check_options{a = {b2 = {c = 0}}}
+check_options{a = {b1 = {c = 0}, b2 = {c = 2}}}
 
 local _l_excess_checks = 2 + debug.getinfo(1).currentline
 function fn_excess_checks(arg1)


### PR DESCRIPTION
1) Checking table type qualifiers does not change any arguments now
(incompatible change, to be released as 3.0.0)
Close #10
 
2) Optimize out creation of temporary tables and strings
* operations with varg `{...}` replaced with `select(...)` functions
* don't check full type name with regex
* don't use string.format until the moment the error is going to be raised