### PR TITLE
Implement support of tuple and decimal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- "tuple" type supported
+- "decimal" type supported
+
 ## [3.0.1] - 2019-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ One can use built-in checkers:
 
   After the check it is safe to call `uuid.frombin()`
 
+* `checks('tuple')`:
+
+  * Check that specified value is tuple
+
+* `checks('decimal')`:
+
+  * Check that specified value is decimal
+
+  (Available since Tarantool 2.4)
 
 ### Optional type and types combination
 

--- a/checks.lua
+++ b/checks.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local _qualifiers_cache = {
     -- ['?type1|type2'] = {
     --     [1] = 'type1',
@@ -228,14 +226,17 @@ function checkers.int64(arg)
     return false
 end
 
-local uuid = require('uuid')
+checkers.tuple = box.tuple.is
+
+local has_decimal, decimal = pcall(require, 'decimal')
+if has_decimal and decimal.is_decimal then
+    checkers.decimal = decimal.is_decimal
+end
+
+-- https://github.com/tarantool/tarantool/blob/7682d34162be34648172d91008e9185301bce8f6/src/lua/uuid.lua#L29
 local uuid_t = ffi.typeof('struct tt_uuid')
 function checkers.uuid(arg)
-    if type(arg) == 'cdata' then
-        return ffi.istype(uuid_t, arg)
-    else
-        return false
-    end
+    return ffi.istype(uuid_t, arg)
 end
 
 function checkers.uuid_str(arg)

--- a/test.lua
+++ b/test.lua
@@ -99,7 +99,7 @@ local function test_err(test, code, expected_line, expected_error)
     -- body
 end
 
-test:plan(150)
+test:plan(155)
 test_err(test, 'fn_number_optstring(1)')
 test_err(test, 'fn_number_optstring(1, nil)')
 test_err(test, 'fn_number_optstring(2, "s")')
@@ -435,5 +435,37 @@ test_ret(test, 'fn_uuid_bin(myid:bin())', true)
 test_ret(test, 'fn_int64(myid)', false)
 test_ret(test, 'fn_uint64(myid)', false)
 test_ret(test, 'fn_uuid(1ULL)', false)
+
+------------------------------------------------------------------------------
+
+function fn_tuple(arg)
+    checks('tuple')
+end
+
+test_ret(test, 'fn_tuple(box.tuple.new({1, 2, 3}))', true)
+test_ret(test, 'fn_tuple({1, 2, 3})', false)
+test_ret(test, 'fn_tuple(1ULL)', false)
+test_ret(test, 'fn_tuple(1)', false)
+
+------------------------------------------------------------------------------
+
+local has_decimal, decimal = pcall(require, 'decimal')
+
+if has_decimal and decimal.is_decimal then
+    function fn_decimal(arg)
+        checks('decimal')
+    end
+
+    test:test('decimal tests', function(test)
+        test:plan(5)
+        test_ret(test, 'fn_decimal(require("decimal").new(123))', true)
+        test_ret(test, 'fn_decimal(require("decimal").new("123"))', true)
+        test_ret(test, 'fn_decimal(123)', false)
+        test_ret(test, 'fn_decimal(1ULL)', false)
+        test_ret(test, 'fn_decimal(1)', false)
+    end)
+else
+    test:skip('decimal is not supported')
+end
 
 os.exit(test:check())


### PR DESCRIPTION
This patch introduces two new checkers:
  - box.tuple
  - decimal (available since Tarantool 2.4)