### PR TITLE
Switch to tagged version of GH action for source code checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}


### PR DESCRIPTION
It is better to stick to a latest tagged version, that considered as
stable, than to a current development version.