### PR TITLE
cd: add package deploy workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,91 @@
+name: packaging
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  package:
+    # Skip pull request jobs when the source branch is in the same
+    # repository.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { os: 'debian', dist: 'stretch' }
+          - { os: 'debian', dist: 'buster' }
+          - { os: 'debian', dist: 'bullseye' }
+          - { os: 'el', dist: '7' }
+          - { os: 'el', dist: '8' }
+          - { os: 'fedora', dist: '30' }
+          - { os: 'fedora', dist: '31' }
+          - { os: 'fedora', dist: '32' }
+          - { os: 'fedora', dist: '33' }
+          - { os: 'fedora', dist: '34' }
+          - { os: 'fedora', dist: '35' }
+          - { os: 'fedora', dist: '36' }
+          - { os: 'ubuntu', dist: 'xenial' }
+          - { os: 'ubuntu', dist: 'bionic' }
+          - { os: 'ubuntu', dist: 'focal' }
+          - { os: 'ubuntu', dist: 'groovy' }
+          - { os: 'ubuntu', dist: 'hirsute' }
+          - { os: 'ubuntu', dist: 'impish' }
+          - { os: 'ubuntu', dist: 'jammy' }
+
+    env:
+      OS: ${{ matrix.platform.os }}
+      DIST: ${{ matrix.platform.dist }}
+
+    steps:
+      - name: Clone the module
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Clone the packpack tool
+        uses: actions/checkout@v2
+        with:
+          repository: packpack/packpack
+          path: packpack
+
+      - name: Fetch tags
+        # Found that Github checkout Actions pulls all the tags, but
+        # right it deannotates the testing tag, check:
+        #   https://github.com/actions/checkout/issues/290
+        # But we use 'git describe ..' calls w/o '--tags' flag and it
+        # prevents us from getting the needed tag for packages version
+        # setup. To avoid of it, let's fetch it manually, to be sure
+        # that all tags will exists always.
+        run: git fetch --tags -f
+
+      - name: Create packages
+        run: ./packpack/packpack
+
+      - name: Deploy packages
+        # We need this step to run only on push with tag.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RWS_URL_PART: https://rws.tarantool.org/tarantool-modules
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          MODULE_NAME: tarantool-checks
+        run: |
+          CURL_CMD="curl -LfsS \
+            -X PUT ${RWS_URL_PART}/${OS}/${DIST} \
+            -u ${RWS_AUTH} \
+            -F product=${MODULE_NAME}"
+
+          for f in $(ls -I '*build*' -I '*.changes' ./build); do
+            CURL_CMD+=" -F $(basename ${f})=@./build/${f}"
+          done
+
+          echo ${CURL_CMD}
+
+          ${CURL_CMD}

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash


### PR DESCRIPTION
This workflow is intended to run on a tag push for creating and
deploying module packages to S3 based repositories. The workflow builds
a package using  and pushes packages via curl request to
rws.tarantool.org

Close #36