### PR TITLE
Migrate to luatest

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -28,4 +28,6 @@ jobs:
         # dependencies when migrating to other OS version.
         run: sudo dpkg -i tarantool*.deb
 
+      - run: make lint
+
       - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
+      - name: Run static analysis
+        run: make lint
+
       - name: Run regression testing
         run: make test
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,4 @@
+include_files = {'**/*.lua', '*.luacheckrc', '*.rockspec'}
+exclude_files = {'.rocks/', 'tmp/', 'build/'}
+max_line_length = 120
+redefined = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed compatibility with LuaJIT.
+- Fixed compatibility with LuaJIT if strict mode is on.
 
 ## [3.1.0] - 2020-10-02
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,24 @@
+TTCTL := tt
+ifeq (,$(shell which tt 2>/dev/null))
+	TTCTL := tarantoolctl
+endif
+
+.PHONY: all
 all:
-	@echo "Only tests are available: make test"
+	@echo "Available commands: .rocks, test, perf, clean"
 
-test:
-	./test.lua
+.rocks: rockspecs/checks-scm-1.rockspec
+	$(TTCTL) rocks make
+	$(TTCTL) rocks install luatest 0.5.7
 
+.PHONY: test
+test: .rocks
+	.rocks/bin/luatest -c -v ./test.lua
+
+.PHONY: perf
 perf:
-	./perftest.lua
+	.rocks/bin/luatest -c ./perftest.lua
+
+.PHONY: clean
+clean:
+	rm -rf .rocks

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,16 @@ endif
 
 .PHONY: all
 all:
-	@echo "Available commands: .rocks, test, perf, clean"
+	@echo "Available commands: .rocks, lint, test, perf, clean"
 
 .rocks: rockspecs/checks-scm-1.rockspec
 	$(TTCTL) rocks make
+	$(TTCTL) rocks install luacheck 0.26.0
 	$(TTCTL) rocks install luatest 0.5.7
+
+.PHONY: lint
+lint: .rocks
+	.rocks/bin/luacheck .
 
 .PHONY: test
 test: .rocks

--- a/checks.lua
+++ b/checks.lua
@@ -19,7 +19,7 @@ local _qualifiers_cache = {
 }
 
 local function is_tarantool()
-    return _G['_TARANTOOL'] ~= nil
+    return rawget(_G, '_TARANTOOL') ~= nil
 end
 
 --- Check that string (or substring) starts with given string
@@ -113,7 +113,7 @@ local function check_string_type(value, expected_type)
             return true
         end
 
-        local checker = _G.checkers[typ]
+        local checker = rawget(_G, 'checkers')[typ]
         if type(checker) == 'function' and checker(value) == true then
             return true
         end
@@ -156,7 +156,7 @@ local function check_table_type(tbl, expected_fields)
                 return nil, string.format(efmt, '%s'..keyname_fmt(expected_key), '%s')
             end
 
-            if _G._checks_v2_compatible and value == nil then
+            if rawget(_G, '_checks_v2_compatible') and value == nil then
                 value = {}
                 tbl[expected_key] = value
             end
@@ -232,7 +232,7 @@ local function checks(...)
                 error(err, level)
             end
 
-            if _G._checks_v2_compatible and value == nil then
+            if rawget(_G, '_checks_v2_compatible') and value == nil then
                 value = {}
                 debug.setlocal(level, i, value)
             end
@@ -253,9 +253,13 @@ local function checks(...)
     end
 end
 
-_G.checks = checks
-_G.checkers = rawget(_G, 'checkers') or {}
-_G._checks_v2_compatible = rawget(_G, '_checks_v2_compatible') or false
+rawset(_G, 'checks', checks)
+
+local checkers = rawget(_G, 'checkers') or {}
+rawset(_G, 'checkers', checkers)
+
+local _checks_v2_compatible = rawget(_G, '_checks_v2_compatible') or false
+rawset(_G, '_checks_v2_compatible', _checks_v2_compatible)
 
 local ffi = require('ffi')
 function checkers.uint64(arg)

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,8 @@
 
 %:
 	dh $@
+
+override_dh_auto_build:
+
+override_dh_auto_test:
+	DEB_BUILD_OPTIONS=nocheck dh_auto_test

--- a/perftest.lua
+++ b/perftest.lua
@@ -1,14 +1,13 @@
 #!/usr/bin/env tarantool
 
-require('strict').on()
-local tap = require('tap')
-local json = require('json')
-local uuid = require('uuid')
-local checks = require('checks')
-local test = tap.test('performance_test')
+local t = require('luatest')
 
-local total_time = 0
-local total_iter = 0
+local checks = require('checks')
+local json = require('json')
+local log = require('log')
+local uuid = require('uuid')
+
+local g = t.group('checks_performance')
 
 local args = {
     ['nil'] = nil,
@@ -23,59 +22,138 @@ local args = {
     ['uuid_bin'] = uuid.bin(),
 }
 
-local function perftest(check, argtype)
-    local fn = function(arg)
-        checks(check)
-    end
+local cases = {
+    {
+        check = '?',
+        argtype = 'nil',
+    },
+    {
+        check = '?',
+        argtype = 'nil',
+    },
 
-    local arg = args[argtype]
+    {
+        check = 'string',
+        argtype = 'string',
+    },
 
-    local cnt = 0
-    local batch_size = 1000
-    local stop
-    local start = os.clock()
-    repeat
-        for i = 1, batch_size do
-            fn(arg)
+    {
+        check = '?string',
+        argtype = 'nil',
+    },
+    {
+        check = '?string',
+        argtype = 'string',
+    },
+
+    {
+        check = 'number|string',
+        argtype = 'string',
+    },
+    {
+        check = 'number|string',
+        argtype = 'number',
+    },
+
+    {
+        check = 'meta',
+        argtype = 'meta',
+    },
+    {
+        check = '?string|meta',
+        argtype = 'nil',
+    },
+    {
+        check = '?string|meta',
+        argtype = 'string',
+    },
+    {
+        check = '?string|meta',
+        argtype = 'meta',
+    },
+
+    {
+        check = 'int64',
+        argtype = 'number',
+    },
+    {
+        check = 'int64',
+        argtype = 'int64',
+    },
+    {
+        check = 'int64',
+        argtype = 'uint64',
+    },
+    {
+        check = 'uint64',
+        argtype = 'number',
+    },
+    {
+        check = 'uint64',
+        argtype = 'int64',
+    },
+    {
+        check = 'uint64',
+        argtype = 'uint64',
+    },
+
+    {
+        check = 'uuid',
+        argtype = 'uuid',
+    },
+    {
+        check = 'uuid_str',
+        argtype = 'uuid_str',
+    },
+    {
+        check = 'uuid_bin',
+        argtype = 'uuid_bin',
+    },
+
+    {
+        check = {x='?'},
+        argtype = 'table',
+    },
+    {
+        check = {x={y='?'}},
+        argtype = 'table',
+    },
+    {
+        check = {x={y={z='?'}}},
+        argtype = 'table',
+    },
+    {
+        check = {x={y={z={t='?'}}}},
+        argtype = 'table',
+    },
+    -- TODO checks({timeout = '?number'}) -- table checker
+}
+
+for _, case in pairs(cases) do
+    -- dots in test case name are not expected
+    local name = ('test_%s_%s'):format(json.encode(case.check), case.argtype):gsub('%.', '_')
+
+    g[name] = function(_)
+        local fn = function(arg) -- luacheck: no unused args
+            checks(case.check)
         end
-        cnt = cnt + batch_size
-        batch_size = math.floor(batch_size * 1.2)
-        stop = os.clock()
-    until stop - start > 1
 
-    local testname = string.format('checks(%s) (%s)', json.encode(check), argtype)
-    test:diag(string.format("  %-35s: %.2f calls/s", testname, cnt/(stop-start) ))
+        local arg = args[case.argtype]
+
+        local cnt = 0
+        local batch_size = 1000
+        local stop
+        local start = os.clock()
+        repeat
+            for _ = 1, batch_size do
+                fn(arg)
+            end
+            cnt = cnt + batch_size
+            batch_size = math.floor(batch_size * 1.2)
+            stop = os.clock()
+        until stop - start > 1
+
+        local testline = string.format('checks(%s) (%s)', json.encode(case.check), case.argtype)
+        log.info("  %-35s: %.2f calls/s", testline, cnt / (stop - start))
+    end
 end
-
-perftest('?', 'nil')
-perftest('?', 'string')
-
-perftest('string', 'string')
-
-perftest('?string', 'nil')
-perftest('?string', 'string')
-
-perftest('number|string', 'string')
-perftest('number|string', 'number')
-
-perftest('meta', 'meta')
-perftest('?string|meta', 'nil')
-perftest('?string|meta', 'string')
-perftest('?string|meta', 'meta')
-
-perftest('int64',  'number')
-perftest('int64',  'int64')
-perftest('int64',  'uint64')
-perftest('uint64', 'number')
-perftest('uint64', 'int64')
-perftest('uint64', 'uint64')
-
-perftest('uuid', 'uuid')
-perftest('uuid_str', 'uuid_str')
-perftest('uuid_bin', 'uuid_bin')
-
-perftest({x='?'}, 'table')
-perftest({x={y='?'}}, 'table')
-perftest({x={y={z='?'}}}, 'table')
-perftest({x={y={z={t='?'}}}}, 'table')
--- TODO checks({timeout = '?number'}) -- table checker


### PR DESCRIPTION
### deb: skip running tests

Running tests with luatest [1] means we need to install luatest first. (It is also not provided in packpack.) Installing external dependency from net while doing deb packing is mostly discouraged, so we skip this step for now (similar to [2]).

1. https://github.com/tarantool/luatest
2. https://github.com/tarantool/expirationd/commit/e13b51db51e12a60b622c9b84b7d13ae9cc1f33c

Part of tarantool/tarantool#7726

### test: migrate to luatest

Rewrite existing regression and performance tests using luatest [1] instead of tap. luatest is a modern tool to write tests for Tarantool core and modules. It is expected for all new tests introduced to the core to be written with luatest, so we rework this before embedding. Add Makefile targets to install and clean dependencies.

1. https://github.com/tarantool/luatest

Part of tarantool/tarantool#7726

### code-health: rawset/rawget for global variables

This patch fixes the following bug: if strict mode is enabled and there is no `_G[_TARANTOOL]`, require fails with "variable '_TARANTOOL' not declared". It also fixes several luacheck warnings about using undeclared global.

Part of tarantool/tarantool#7726

### test: add linting stage

Statically validate module code and tests with luacheck [1]. Run linting stage as a first step of regression tests.

1. https://github.com/tarantool/luacheck

Part of tarantool/tarantool#7726