### PR TITLE
New checks types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - "error" type supported.
 - "datetime" type supported.
+- "interval" type supported.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- "error" type supported.
+
 ### Fixed
 
 - Fixed compatibility with LuaJIT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - "error" type supported.
+- "datetime" type supported.
 
 ### Fixed
 

--- a/checks.lua
+++ b/checks.lua
@@ -347,4 +347,6 @@ function checkers.uuid_bin(arg)
     end
 end
 
+add_ffi_type_checker('error', 'struct error')
+
 return checks

--- a/checks.lua
+++ b/checks.lua
@@ -349,4 +349,9 @@ end
 
 add_ffi_type_checker('error', 'struct error')
 
+local has_datetime, datetime = pcall(require, 'datetime')
+if has_datetime then
+    checkers.datetime = datetime.is_datetime
+end
+
 return checks

--- a/checks.lua
+++ b/checks.lua
@@ -354,4 +354,6 @@ if has_datetime then
     checkers.datetime = datetime.is_datetime
 end
 
+add_ffi_type_checker('interval', 'struct interval')
+
 return checks

--- a/test.lua
+++ b/test.lua
@@ -624,6 +624,15 @@ end
 
 local has_error = (box.error ~= nil) and (box.error.new ~= nil)
 
+function testdata.fn_datetime(arg) -- luacheck: no unused args
+    checks('datetime')
+end
+
+local has_datetime, datetime = pcall(require, 'datetime')
+if has_datetime then
+    testdata.datetime = datetime
+end
+
 local ret_cases = {
     -- fn_int64
     {
@@ -968,6 +977,64 @@ local ret_cases = {
     {
         skip = not has_error,
         code = 'fn_error(1)',
+        ok = false,
+    },
+
+    -- fn_datetime
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new())',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new{year=2023, month=1, day=11})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new{nsec=1001001})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new{timestamp=1673439642})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new{tzoffset=180})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(datetime.new{tz="Europe/Moscow"})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime()',
+        ok = false,
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime("1.11.2023")',
+        ok = false,
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime(1673439642)',
+        ok = false,
+    },
+    {
+        skip = not has_datetime,
+        code = 'fn_datetime({year=2023, month=1, day=11})',
         ok = false,
     },
 }

--- a/test.lua
+++ b/test.lua
@@ -633,6 +633,12 @@ if has_datetime then
     testdata.datetime = datetime
 end
 
+function testdata.fn_interval(arg) -- luacheck: no unused args
+    checks('interval')
+end
+
+local has_interval = has_datetime and datetime.interval ~= nil
+
 local ret_cases = {
     -- fn_int64
     {
@@ -1035,6 +1041,36 @@ local ret_cases = {
     {
         skip = not has_datetime,
         code = 'fn_datetime({year=2023, month=1, day=11})',
+        ok = false,
+    },
+
+    -- fn_interval
+    {
+        skip = not has_interval,
+        code = 'fn_interval(datetime.interval.new())',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_interval,
+        code = 'fn_interval(datetime.interval.new{day=1})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_interval,
+        code = 'fn_interval(datetime.interval.new{month=1, adjust="last"})',
+        ok = true,
+        additional_data = {'datetime'},
+    },
+    {
+        skip = not has_interval,
+        code = 'fn_interval()',
+        ok = false,
+    },
+    {
+        skip = not has_interval,
+        code = 'fn_interval({month=1, adjust="last"})',
         ok = false,
     },
 }

--- a/test.lua
+++ b/test.lua
@@ -618,6 +618,12 @@ if has_decimal then
     testdata.decimal = decimal
 end
 
+function testdata.fn_error(arg) -- luacheck: no unused args
+    checks('error')
+end
+
+local has_error = (box.error ~= nil) and (box.error.new ~= nil)
+
 local ret_cases = {
     -- fn_int64
     {
@@ -935,6 +941,33 @@ local ret_cases = {
     {
         skip = not has_decimal,
         code = 'fn_decimal(1)',
+        ok = false,
+    },
+
+    -- fn_error
+    {
+        skip = not has_error,
+        code = 'fn_error(box.error.new(box.error.UNKNOWN))',
+        ok = true,
+    },
+    {
+        skip = not has_error,
+        code = 'fn_error(box.error.UNKNOWN)', -- It's an error code, not an error object.
+        ok = false,
+    },
+    {
+        skip = not has_error,
+        code = 'fn_error(select(2, pcall(error, "my error")))',
+        ok = false,
+    },
+    {
+        skip = not has_error,
+        code = 'fn_error()',
+        ok = false,
+    },
+    {
+        skip = not has_error,
+        code = 'fn_error(1)',
         ok = false,
     },
 }


### PR DESCRIPTION
### code-health: rework Tarantool type checkers

Change Tarantool type checkers builder to add checkers if there are expected modules.

Part of tarantool/tarantool#7726

### feature: support error type

Support error type checks for box.error objects [1] (can be explicitly created in Tarantool Lua scripts since 2.4.1).

1. https://github.com/tarantool/tarantool/issues/4398

Part of tarantool/tarantool#7726

### feature: support datetime type

Support datetime type checks [1] (added in Tarantool 2.10.0).

1. https://github.com/tarantool/tarantool/issues/5941

Part of tarantool/tarantool#7726

### feature: support interval type

Support interval type checks [1] (added in Tarantool 2.10.0).

1. https://github.com/tarantool/tarantool/issues/5941

Part of tarantool/tarantool#7726