### PR TITLE
dev: ignore .lua.c files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Testing/
 *.dylib
 packpack
 .rocks
+
+*.lua.c


### PR DESCRIPTION
.lua.c files are built when the module embeds to the core. Not ignoring them makes in-source build dirty, see https://github.com/tarantool/tarantool/pull/8139#discussion_r1105671687.

Part of tarantool/tarantool#7726