### PR TITLE
test: adjust built-in checks removal

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,5 +1,10 @@
 -- Clean up built-in checks to run tests with repository module.
 package.loaded['checks'] = nil
+local ok, loaders = pcall(require, 'internal.loaders')
+if ok then
+    loaders.builtin['checks'] = nil
+end
+
 local checks = require('checks')
 
 local package_source = debug.getinfo(checks).source


### PR DESCRIPTION
Tarantool 2.11.0-rc1 and newer need more actions to discard a built-in module.

See https://github.com/tarantool/tarantool/pull/8300 for details.