### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,12 +8,32 @@ on:
       - '*'
 
 jobs:
+  # Run not only on tags, otherwise dependent job will skip.
+  version-check:
+    # Skip pull request jobs when the source branch is in the same
+    # repository.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: checks
+          version-pre-extraction-hook: |
+            local rock_utils = require('test.rock_utils')
+            rock_utils.remove_builtin('checks')
+            rock_utils.assert_nonbuiltin('checks')
+
   package:
     # Skip pull request jobs when the source branch is in the same
     # repository.
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
+    needs: version-check
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/push_rockspec.yml
+++ b/.github/workflows/push_rockspec.yml
@@ -14,6 +14,20 @@ env:
   ROCK_NAME: "checks"
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: checks
+          version-pre-extraction-hook: |
+            local rock_utils = require('test.rock_utils')
+            rock_utils.remove_builtin('checks')
+            rock_utils.assert_nonbuiltin('checks')
+
   push-scm-rockspec:
     runs-on: [ ubuntu-20.04 ]
     if: github.ref == 'refs/heads/master' && github.event.workflow_run.conclusion == 'success'
@@ -28,6 +42,7 @@ jobs:
   push-tagged-rockspec:
     runs-on: [ ubuntu-20.04 ]
     if: startsWith(github.ref, 'refs/tags')
+    needs: version-check
     steps:
       - uses: actions/checkout@master
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ packpack
 .rocks
 
 *.lua.c
+
+packpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Versioning supported.
+
 ## [3.2.0] - 2023-01-27
 ### Added
 

--- a/checks-scm-1.rockspec
+++ b/checks-scm-1.rockspec
@@ -24,6 +24,7 @@ build = {
     type = 'builtin',
     modules = {
         ['checks'] = 'checks.lua',
+        ['checks.version'] = 'checks/version.lua',
     }
 }
 

--- a/checks.lua
+++ b/checks.lua
@@ -356,4 +356,14 @@ end
 
 add_ffi_type_checker('interval', 'struct interval')
 
-return checks
+return setmetatable(
+    {
+        checks = checks,
+    },
+    {
+        -- Made export table callable for backward compatibility.
+        __call = function(_, ...)
+            return checks(...)
+        end
+    }
+)

--- a/checks.lua
+++ b/checks.lua
@@ -359,6 +359,7 @@ add_ffi_type_checker('interval', 'struct interval')
 return setmetatable(
     {
         checks = checks,
+        _VERSION = require('checks.version'),
     },
     {
         -- Made export table callable for backward compatibility.

--- a/checks/version.lua
+++ b/checks/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '3.2.0'

--- a/debian/tarantool-checks.install
+++ b/debian/tarantool-checks.install
@@ -1,1 +1,2 @@
 checks.lua usr/share/tarantool/
+checks usr/share/tarantool/

--- a/rpm/tarantool-checks.spec
+++ b/rpm/tarantool-checks.spec
@@ -21,9 +21,11 @@ Easy, terse, readable and fast function arguments type checking.
 %install
 mkdir -p %{br_luapkgdir}
 cp -av checks.lua %{br_luapkgdir}
+cp -rv checks %{br_luapkgdir}
 
 %files
 %{luapkgdir}/checks.lua
+%{luapkgdir}/checks
 %doc README.md
 %{!?_licensedir:%global license %doc}
 %license LICENSE

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,11 +1,4 @@
 -- Clean up built-in checks to run tests with repository module.
-package.loaded['checks'] = nil
-local ok, loaders = pcall(require, 'internal.loaders')
-if ok then
-    loaders.builtin['checks'] = nil
-end
-
-local checks = require('checks')
-
-local package_source = debug.getinfo(checks).source
-assert(package_source:match('^@builtin') == nil, 'Run tests for repository checks package')
+local rock_utils = require('test.rock_utils')
+rock_utils.remove_builtin('checks')
+rock_utils.assert_nonbuiltin('checks')

--- a/test/rock_utils.lua
+++ b/test/rock_utils.lua
@@ -1,0 +1,79 @@
+local loaders_ok, loaders = pcall(require, 'internal.loaders')
+
+local function traverse_rock(func, name)
+    func(name, package.loaded[name])
+
+    for subpkg_name, subpkg in pairs(package.loaded) do
+        if subpkg_name:startswith(name .. '.') then
+            func(subpkg_name, subpkg)
+        end
+    end
+end
+
+-- Package functions contain useful debug info.
+local function traverse_pkg_func(func, name, pkg)
+    if type(pkg) == 'function' then
+        func(name, pkg)
+        return
+    end
+
+    if type(pkg) ~= 'table' then
+        return
+    end
+
+    for _, v in pairs(pkg) do
+        traverse_pkg_func(func, name, v)
+    end
+
+    local mt = getmetatable(pkg)
+    if mt.__call ~= nil then
+        func(name, mt.__call)
+    end
+end
+
+local function remove_builtin_pkg(name, _)
+    package.loaded[name] = nil
+    if loaders_ok then
+        loaders.builtin[name] = nil
+    end
+end
+
+local function assert_nonbuiltin_func(pkg_name, func)
+    local source = debug.getinfo(func).source
+    assert(source:match('^@builtin') == nil,
+           ("package %s is built-in, cleanup failed"):format(pkg_name))
+end
+
+local function assert_builtin_func(pkg_name, func)
+    local source = debug.getinfo(func).source
+    assert(source:match('^@builtin') ~= nil,
+           ("package %s is external, built-in expected"):format(pkg_name))
+end
+
+local function assert_nonbuiltin_pkg(name, pkg)
+    traverse_pkg_func(assert_nonbuiltin_func, name, pkg)
+end
+
+local function assert_builtin_pkg(name, pkg)
+    traverse_pkg_func(assert_builtin_func, name, pkg)
+end
+
+local function remove_builtin_rock(name)
+    traverse_rock(remove_builtin_pkg, name)
+end
+
+local function assert_nonbuiltin_rock(name)
+    require(name)
+    traverse_rock(assert_nonbuiltin_pkg, name)
+end
+
+local function assert_builtin_rock(name)
+    require(name)
+    traverse_rock(assert_builtin_pkg, name)
+end
+
+return {
+    assert_builtin = assert_builtin_rock,
+    assert_nonbuiltin = assert_nonbuiltin_rock,
+    remove_builtin = remove_builtin_rock,
+}

--- a/test/test.lua
+++ b/test/test.lua
@@ -1108,3 +1108,7 @@ for _, case in pairs(ret_cases) do
         end
     end)
 end
+
+g.test_version = function()
+    t.assert_type(require('checks')._VERSION, 'string')
+end


### PR DESCRIPTION
Before this patch, checks was a function. After this patch, it will be a callable table. The behavior should be the same, but now the module can be extended with new API. User also may call `checks.checks` now.

Added the _VERSION variable to the exported table. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204