### PR TITLE
ci: do not publish deb for interim Ubuntu

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -53,9 +53,6 @@ jobs:
           - { os: 'ubuntu', dist: 'xenial' }
           - { os: 'ubuntu', dist: 'bionic' }
           - { os: 'ubuntu', dist: 'focal' }
-          - { os: 'ubuntu', dist: 'groovy' }
-          - { os: 'ubuntu', dist: 'hirsute' }
-          - { os: 'ubuntu', dist: 'impish' }
           - { os: 'ubuntu', dist: 'jammy' }
 
     env:


### PR DESCRIPTION
Ubuntu 20.10 (Groovy) EOL is July, 2020 [1]. Ubuntu 21.04 (Hirsute) EOL is January, 2022 [1]. Ubuntu 21.10 (Impish) EOL is July, 2022, but packing deb for it already fails with "E: The repository 'http://archive.ubuntu.com/ubuntu impish Release' does not have a Release file.". Since we don't provide core Tarantool releases for interim Ubuntu releases now and it doesn't work for `checks` deb packages, it sounds reasonable do not publish them at all.

1. https://endoflife.software/operating-systems/linux/ubuntu