### PR TITLE
ci: bump ubuntu version

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
@@ -32,7 +32,7 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
     needs: version-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -41,6 +41,7 @@ jobs:
           - { os: 'debian', dist: 'stretch' }
           - { os: 'debian', dist: 'buster' }
           - { os: 'debian', dist: 'bullseye' }
+          - { os: 'debian', dist: 'bookworm' }
           - { os: 'el', dist: '7' }
           - { os: 'el', dist: '8' }
           - { os: 'fedora', dist: '30' }
@@ -54,6 +55,7 @@ jobs:
           - { os: 'ubuntu', dist: 'bionic' }
           - { os: 'ubuntu', dist: 'focal' }
           - { os: 'ubuntu', dist: 'jammy' }
+          - { os: 'ubuntu', dist: 'noble' }
 
     env:
       OS: ${{ matrix.platform.os }}
@@ -61,12 +63,12 @@ jobs:
 
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Clone the packpack tool
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: packpack/packpack
           path: packpack

--- a/.github/workflows/push_rockspec.yml
+++ b/.github/workflows/push_rockspec.yml
@@ -17,7 +17,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -27,7 +27,7 @@ jobs:
             require('test.rock_utils').assert_nonbuiltin('checks')
 
   push-scm-rockspec:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ ubuntu-24.04 ]
     if: github.ref == 'refs/heads/master' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@master
@@ -38,7 +38,7 @@ jobs:
           files: ${{ env.ROCK_NAME }}-scm-1.rockspec
 
   push-tagged-rockspec:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ ubuntu-24.04 ]
     if: startsWith(github.ref, 'refs/tags')
     needs: version-check
     steps:

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       artifact_name:
         description: The name of the tarantool build artifact
-        default: ubuntu-focal
+        default: ubuntu-jammy
         required: false
         type: string
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the checks module
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8', '2.10']
+        tarantool: ['1.10','2.11', '3.3']
 
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v3
-      - uses: tarantool/setup-tarantool@v2
+      - uses: actions/checkout@v4
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
@@ -36,9 +36,9 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup LuaJIT
         run: sudo apt install -y luajit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project(checks NONE)
 

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -2,4 +2,13 @@
 
 set -e -o pipefail
 
-curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
+if [[ $DIST == "noble" ]] || [[ $DIST == "bookworm" ]]; then
+  curl -LsSf https://www.tarantool.io/release/3/installer.sh | sudo bash
+elif [[ $DIST == "impish" ]] || [[ $DIST == "jammy" ]]; then
+  curl -LsSf https://www.tarantool.io/release/2/installer.sh | sudo bash
+else
+  curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
+fi
+
+sudo apt install -y tt
+tt version


### PR DESCRIPTION
This patch bumps actions to use ubuntu-24.04 for fixing the following GitHub
warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Removes unsupported OSes from packaging matrix, cleans list of
Tarantool versions to test.

Part of #TNTP-1918
Closes #64