### PR TITLE
cmake: bump min version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(checks NONE)
 


### PR DESCRIPTION
Compatibility with CMake < 3.5 has been removed from CMake.