### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [3.4.0] - 2025-10-21
+
+This release introduces bumped CMake version to avoid compatibility
+problem with CMake 4.x.
+
+### Changed
+
+- Bump CMake version to avoid compatibility problem with CMake 4.x (#66).
+
 ## [3.3.0] - 2023-04-19
 
 ### Added
@@ -16,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Override built-in checks, if installed.
 
 ## [3.2.0] - 2023-01-27
+
 ### Added
 
 - "error" type supported.

--- a/checks/version.lua
+++ b/checks/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '3.3.0'
+return '3.4.0'


### PR DESCRIPTION
This release introduces bumped CMake version to avoid compatibility
problem with CMake 4.x.

### Changed

- Bump CMake version to avoid compatibility problem with CMake 4.x (#66).